### PR TITLE
registry: normalize values on flush (NaN/Inf -> 0)

### DIFF
--- a/distribution.go
+++ b/distribution.go
@@ -24,6 +24,23 @@ type Distribution interface {
 	Variance() float64
 }
 
+// NormalizedDistribution converts any NaN/Inf values to zeros.
+func NormalizedDistribution(d Distribution) Distribution {
+	return normalizedDistribution{d}
+}
+
+type normalizedDistribution struct {
+	d Distribution
+}
+
+func (d normalizedDistribution) Count() int                 { return d.d.Count() }
+func (d normalizedDistribution) Min() float64               { return normalizeFloat64(d.d.Min()) }
+func (d normalizedDistribution) Max() float64               { return normalizeFloat64(d.d.Max()) }
+func (d normalizedDistribution) Sum() float64               { return normalizeFloat64(d.d.Sum()) }
+func (d normalizedDistribution) Mean() float64              { return normalizeFloat64(d.d.Mean()) }
+func (d normalizedDistribution) Quantile(q float64) float64 { return normalizeFloat64(d.d.Quantile(q)) }
+func (d normalizedDistribution) Variance() float64          { return normalizeFloat64(d.d.Variance()) }
+
 // --------------------------------------------------------------------
 
 const defaultHistogramSize = 20

--- a/registry.go
+++ b/registry.go
@@ -150,14 +150,14 @@ func (r *Registry) Flush() error {
 
 		switch inst := val.(type) {
 		case Discrete:
-			val := inst.Snapshot()
+			val := normalizeFloat64(inst.Snapshot())
 			for _, rep := range reporters {
 				if err := rep.Discrete(name, tags, val); err != nil {
 					return err
 				}
 			}
 		case Sample:
-			val := inst.Snapshot()
+			val := NormalizedDistribution(inst.Snapshot())
 			for _, rep := range reporters {
 				if err := rep.Sample(name, tags, val); err != nil {
 					return err

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package instruments
 
 import (
+	"math"
 	"strings"
 )
 
@@ -60,4 +61,12 @@ func findMinString(slice []string, greaterThan string) string {
 		}
 	}
 	return min
+}
+
+// normalizeFloat64 converts NaN/Inf value to 0 or returns it as is otherwise.
+func normalizeFloat64(v float64) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0
+	}
+	return v
 }


### PR DESCRIPTION
https://github.com/bsm/histogram returns NaN if Count == 0.

I considered this very simple, so did not bother with adding tests.

I'm not sure if zero-ing values is the best idea - probably, we should just **skip** those values? Skipping would make sense for distribution metrics with zero Count.